### PR TITLE
Add 'ay' diphthong to phonology

### DIFF
--- a/refgram/03/index.html
+++ b/refgram/03/index.html
@@ -146,7 +146,7 @@ title: Phonology
 		<td>  </td>
 		<td>  </td>
 		<td>  </td>
-		<td>  </td>
+		<td> ay </td>
 	</tr>
 	<tr>
 		<td> u </td>


### PR DESCRIPTION
It's in common use in **may ray zay ay**, and nobody actively dislikes it, if this poll from September 2021 is to be believed: https://www.strawpoll.me/45644656/r

I will leave the final decision to @solpahi :)