### PR TITLE
Lock in `zay` and `fou`

### DIFF
--- a/refgram/18/index.html
+++ b/refgram/18/index.html
@@ -55,7 +55,7 @@ title: Illocutions
 	<td></td>
 </tr>
 <tr>
-	<td><span class="toaq">???</span></td>
+	<td><span class="toaq">zay</span></td>
 	<td>warning</td>
 	<td></td>
 </tr>
@@ -324,13 +324,13 @@ title: Illocutions
   </table><div style="clear:both;"></div>
 </button>
 
-<p>The <span class="toaq">???</span> illocution expresses warnings by providing information the listener should heed.:</p>
+<p>The <span class="toaq">zay</span> illocution expresses warnings by providing information the listener should heed.:</p>
 
 <button class="listen" onclick="PlaySound('tủı súq shou')">
 <table class="example">
     <tr>
       <th><div class="exindent"></div></th>
-      <th>Jỉa</th><th>rủqshua</th><th>rào</th><th>níchaq</th><th>???.</th>
+      <th>Jỉa</th><th>rủqshua</th><th>rào</th><th>níchaq</th><th>zay.</th>
     </tr>
     <tr>
       <td class="left"></td>
@@ -343,11 +343,11 @@ title: Illocutions
   </table><div style="clear:both;"></div>
 </button>
 
-<button class="listen" onclick="PlaySound('ảrane ???')">
+<button class="listen" onclick="PlaySound('ảrane zay')">
 <table class="example">
     <tr>
       <th><div class="exindent"></div></th>
-      <th>Ảrane</th><th>???!</th>
+      <th>Ảrane</th><th>zay!</th>
     </tr>
     <tr>
       <td class="left"></td>

--- a/refgram/19/index.html
+++ b/refgram/19/index.html
@@ -33,7 +33,7 @@ title: Sentence connectors
 	<td>“so”, “therefore”</td>
 </tr>
 <tr>
-	<td><span class="toaq">???</span></td>
+	<td><span class="toaq">fou</span></td>
 	<td>“by the way” (go on tangent)</td>
 </tr>
 <tr>


### PR DESCRIPTION
@solpahi How do you feel about **zay** as a warning illocution and **fou** as a "by the way" connector?

Both have seen significant use on Discord, and I personally think both sound cool. Might make the most sense at this point to just lock them in because people keep asking about the `???` in the refgram.