### PR TITLE
New syllable endings table (closes #17); fix dotless roı

### DIFF
--- a/kata/index.html
+++ b/kata/index.html
@@ -970,11 +970,11 @@ director   role 1    role 2
   
   <h2 id="me_and_you_together">Me and you together</h2>
   
-  <p>To group multiple nouns together to say that they do something together, <b>roi</b> can be used: </p>
+  <p>To group multiple nouns together to say that they do something together, <b>roı</b> can be used: </p>
   
   <table class="def">
     <tr>
-      <td>Pattern: <br><br>NOUN <b>roi</b> NOUN => NOUN'</td>
+      <td>Pattern: <br><br>NOUN <b>roı</b> NOUN => NOUN'</td>
     </tr>
   </table>
   
@@ -982,7 +982,7 @@ director   role 1    role 2
   
   <table class="def">
     <tr>
-      <td><span class="tone4">Chẻo</span> <span class="tone4">mảı</span> <span class="tone2">súq</span> roi <span class="tone2">jí</span> da.<br><br>"You & I love each other."</td>
+      <td><span class="tone4">Chẻo</span> <span class="tone4">mảı</span> <span class="tone2">súq</span> roı <span class="tone2">jí</span> da.<br><br>"You & I love each other."</td>
     </tr>
   </table>
   
@@ -990,7 +990,7 @@ director   role 1    role 2
   
   <table class="def">
     <tr>
-      <td><span class="tone4">Gủ</span> <span class="tone2">súq</span> roi <span class="tone2">jí</span> da.<br><br>"You & I are two."</td>
+      <td><span class="tone4">Gủ</span> <span class="tone2">súq</span> roı <span class="tone2">jí</span> da.<br><br>"You & I are two."</td>
     </tr>
   </table>
   

--- a/refgram/03/index.html
+++ b/refgram/03/index.html
@@ -132,102 +132,12 @@ title: Phonology
 <p>Toaq's syllable structure is simple: An initial consonant is followed by one of the following endings:</p>
 
 <table class="endings">
-	<tr>
-		<td> a </td>
-		<td> aq </td>
-		<td>  </td>
-		<td>  </td>
-		<td> aı </td>
-		<td> ao </td>
-		<td>  </td>
-		<td>  </td>
-		<td>  </td>
-		<td>  </td>
-		<td>  </td>
-		<td>  </td>
-		<td>  </td>
-		<td> ay </td>
-	</tr>
-	<tr>
-		<td> u </td>
-		<td> uq </td>
-		<td> ua </td>
-		<td> uaq</td>
-		<td> uı </td>
-		<td> uo </td>
-		<td> uoı </td>
-		<td> uoq </td>
-		<td> ue </td>
-		<td> ueq </td>
-		<td> uaı </td>
-		<td> uao </td>
-		<td>  </td>
-		<td> uy </td>
-	</tr>
-	<tr>
-		<td> ı </td>
-		<td> ıq </td>
-		<td> ıa </td>
-		<td> ıaq </td>
-		<td>  </td>
-		<td> ıo </td>
-		<td>  </td>
-		<td> ıoq </td>
-		<td> ıe </td>
-		<td> ıeq </td>
-		<td> ıaı </td>
-		<td> ıao </td>
-		<td> ıu </td>
-		<td> ıy </td>
-	</tr>
-	<tr>
-		<td> o </td>
-		<td> oq </td>
-		<td> oa </td>
-		<td> oaq </td>
-		<td> oı </td>
-		<td>  </td>
-		<td>  </td>
-		<td>  </td>
-		<td> oe </td>
-		<td> oeq </td>
-		<td> oaı </td>
-		<td>  </td>
-		<td> ou </td>
-		<td> oy </td>
-	</tr>
-	<tr>
-		<td> e </td>
-		<td> eq </td>
-		<td> ea </td>
-		<td> eaq </td>
-		<td> eı </td>
-		<td> eo </td>
-		<td>  </td>
-		<td>  </td>
-		<td>  </td>
-		<td> eoq </td>
-		<td> eaı </td>
-		<td>  </td>
-		<td>  </td>
-		<td> ey </td>
-	</tr>
-	<tr>
-		<td> y </td>
-		<td>  </td>
-		<td>  </td>
-		<td>  </td>
-		<td>  </td>
-		<td>  </td>
-		<td>  </td>
-		<td>  </td>
-		<td>  </td>
-		<td>  </td>
-		<td>  </td>
-		<td>  </td>
-		<td>  </td>
-		<td>  </td>
-	</tr>
+  <tr><td>a</td><td>aq</td><td>aı</td><td>ao</td><td>  </td><td>   </td><td>  </td><td>   </td><td>  </td><td>   </td><td>   </td><td>   </td><td>   </td><td>  </td><td>ay</td></tr>
+  <tr><td>u</td><td>uq</td><td>  </td><td>  </td><td>ua</td><td>uaq</td><td>uo</td><td>uoq</td><td>ue</td><td>ueq</td><td>uaı</td><td>uao</td><td>uoı</td><td>uı</td><td>uy</td></tr>
+  <tr><td>ı</td><td>ıq</td><td>  </td><td>  </td><td>ıa</td><td>ıaq</td><td>ıo</td><td>ıoq</td><td>ıe</td><td>ıeq</td><td>ıaı</td><td>ıao</td><td>   </td><td>ıu</td><td>ıy</td></tr>
+  <tr><td>o</td><td>oq</td><td>oı</td><td>ou</td><td>oa</td><td>oaq</td><td>  </td><td>   </td><td>oe</td><td>oeq</td><td>oaı</td><td>   </td><td>   </td><td>  </td><td>oy</td></tr>
+  <tr><td>e</td><td>eq</td><td>eı</td><td>  </td><td>ea</td><td>eaq</td><td>eo</td><td>eoq</td><td>  </td><td>   </td><td>eaı</td><td>   </td><td>   </td><td>  </td><td>ey</td></tr>
+  <tr><td>y</td><td>  </td><td>  </td><td>  </td><td>  </td><td>   </td><td>  </td><td>   </td><td>  </td><td>   </td><td>   </td><td>   </td><td>   </td><td>  </td><td>  </td></tr>
 </table>
 
 <p>Any consonant other than /ŋ/ is a valid initial. Consonant clusters (sequences of more than one consonant phoneme in a row) are not permissible in onset position, but can occur at the word or syllable boundary (/ŋ/ followed by a simple onset).</p>

--- a/refgram/22/index.html
+++ b/refgram/22/index.html
@@ -29,7 +29,7 @@ title: Coordination
       <td>"exclusive or", "either ... or ..., but not both"</td>
     </tr>
     <tr>
-      <td><span class="toaq">roi</span></td>
+      <td><span class="toaq">roı</span></td>
       <td>"plural and", "together with"</td>
     </tr>
     <tr>


### PR DESCRIPTION
I applied Hoemai's first comment in https://github.com/toaq/toaq.github.io/issues/17#issuecomment-1058362985 but not the second, to keep the table from becoming too wide.