### PR TITLE
missing VQ rimes, minor spelling stuff in refgram's phonology

### DIFF
--- a/refgram/phonology/index.html
+++ b/refgram/phonology/index.html
@@ -288,6 +288,7 @@ layout: delta-refgram
 <tbody>
   <tr>
     <td>a</td>
+	<td>aQ</td>
     <td></td>
     <td></td>
     <td></td>
@@ -302,6 +303,7 @@ layout: delta-refgram
   </tr>
   <tr>
     <td>u</td>
+    <td>uQ</td>
     <td>ua</td>
     <td>uaQ</td>
     <td></td>
@@ -316,6 +318,7 @@ layout: delta-refgram
   </tr>
   <tr>
     <td>ı</td>
+    <td>ıQ</td>
     <td>ıa</td>
     <td>ıaQ</td>
     <td>ıu</td>
@@ -330,6 +333,7 @@ layout: delta-refgram
   </tr>
   <tr>
     <td>o</td>
+    <td>oQ</td>
     <td>oa</td>
     <td>oaQ</td>
     <td></td>
@@ -344,6 +348,7 @@ layout: delta-refgram
   </tr>
   <tr>
     <td>e</td>
+    <td>eQ</td>
     <td>ea</td>
     <td>eaQ</td>
     <td>eu</td>

--- a/refgram/phonology/index.html
+++ b/refgram/phonology/index.html
@@ -415,7 +415,7 @@ layout: delta-refgram
 </tbody>
 </table>
 
-<p>(The <span class="mono">oF</span> and <span class="mono">eF</span> rimes exclude the forms <span class="mono">*ooı</span> and <span class="mono">*eeı</span>, because they contain repeated vowels, which are impermermissible)</p>
+<p>(The <span class="mono">oF</span> and <span class="mono">eF</span> rimes exclude the forms <span class="mono">*ooı</span> and <span class="mono">*eeı</span>, because they contain repeated vowels, which are impermissible)</p>
 
 
 

--- a/refgram/phonology/index.html
+++ b/refgram/phonology/index.html
@@ -88,7 +88,7 @@ layout: delta-refgram
 </tbody>
 </table>
 
-<p>Any consonant other than /ŋ/ can appear syllable-initially. When disscussing syllable structure, initial consonants are abbreviated as <span class="mono">C</span>.</p>
+<p>Any consonant other than /ŋ/ can appear syllable-initially. When discussing syllable structure, initial consonants are abbreviated as <span class="mono">C</span>.</p>
 
 <p>/ŋ/ can only appear in syllable-final position.</p>
 
@@ -141,7 +141,7 @@ layout: delta-refgram
 
 <p>For example, <span class="toaq">nogı</span> is pronounced [ˈnoː.gi], <span class="toaq">noqgı</span> is pronounced [ˈnɔŋ.gi], and <span class="toaq">nomgı</span> is pronounced [ˈnoːm.gi].
 
-<p>Toaq has four falling dipthongs. When discussing syllable structure, these are abbreviated as <span class="mono">F</span>:</p>
+<p>Toaq has four falling diphthongs. When discussing syllable structure, these are abbreviated as <span class="mono">F</span>:</p>
 
 <table class="vowels">
 <tbody>
@@ -177,7 +177,7 @@ layout: delta-refgram
 
 <p>The same vowel may not appear more than once in a row: /aa/, /uu/, /ii/, /oo/, /ɛɛ/ are impermissible.</p>
 
-<p>/a/ may not be followed by any vowel with which it does not form a falling dipthong.</p>
+<p>/a/ may not be followed by any vowel with which it does not form a falling diphthong.</p>
 
 <p>/o/ may not be followed by /u/.</p>
 
@@ -226,10 +226,10 @@ layout: delta-refgram
 	<p>A <i>raku</i> consists of a mandatory onset, followed by a rime, which consists of a mandatory nucleus followed by an optional coda. The coda consists of two optional components: the secondary nucleus and the final.</p>
 
 	<p>The onset is an initial consonant (C), which is any consonant that  isn't /ŋ/.</p>
-	<p>The nucleus is any vowel (<span class="mono">V</span>) or any falling dipthong (<span class="mono">F</span>).</p>
-	<p>The secondary nucleus is any vowel (<span class="mono">V</span>) or any falling dipthong (<span class="mono">F</span>).</p>
+	<p>The nucleus is any vowel (<span class="mono">V</span>) or any falling diphthong (<span class="mono">F</span>).</p>
+	<p>The secondary nucleus is any vowel (<span class="mono">V</span>) or any falling diphthong (<span class="mono">F</span>).</p>
 	<p>The final is either /ŋ/ or /m/ (<span class="mono">Q</span>).</p>
-	<p>When either nucleus contains a falling dipthong, no further material can follow it in the same <i>raku</i>.</p>
+	<p>When either nucleus contains a falling diphthong, no further material can follow it in the same <i>raku</i>.</p>
 	<p>When both nuclei are non-empty, they are separated by a hiatus.</p>
 </div>
 
@@ -415,7 +415,7 @@ layout: delta-refgram
 </tbody>
 </table>
 
-<p>(The <span class="mono">oF</span> and <span class="mono">eF</span> rimes exclude the forms <span class="mono">*ooı</span> and <span class="mono">*eeı</span>, because they contain repeated vowels, which are impermissable.)</p>
+<p>(The <span class="mono">oF</span> and <span class="mono">eF</span> rimes exclude the forms <span class="mono">*ooı</span> and <span class="mono">*eeı</span>, because they contain repeated vowels, which are impermermissible)</p>
 
 
 


### PR DESCRIPTION
The existing rime table lacks rimes aQ, eQ, ıQ, oQ and uQ
![Ekran Görüntüsü - 2025-05-24 14-53-05](https://github.com/user-attachments/assets/ab964a50-5ef4-4679-a8ff-b0a6313abbf9)

In addition, there are these spelling mistakes:
dipthong > diphthong
disscussing > discussing
impermissable > impermissible